### PR TITLE
Changed the build method

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+# Source
+# https://core.trac.wordpress.org/browser/trunk/.editorconfig
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{*.txt,wp-config-sample.php}]
+end_of_line = crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,44 @@
+# Ignore local configuration files.
+/.env
+/wp-config-local.php
+
+# Ignore Composer packages.
 /vendor/
-/web/wp/
+
+# Temporary and build directories.
+/wp/
+/_www
+
+# Standard Wordpress files and folders:
+/web/composer.json
+/web/index.php
+/web/license.txt
+/web/readme.html
+/web/wp-activate.php
+/web/wp-admin/
+/web/wp-blog-header.php
+/web/wp-comments-post.php
+/web/wp-config-sample.php
+/web/wp-content/index.php
+/web/wp-content/plugins/index.php
+/web/wp-content/themes/index.php
+/web/wp-cron.php
+/web/wp-includes/
+/web/wp-links-opml.php
+/web/wp-load.php
+/web/wp-login.php
+/web/wp-mail.php
+/web/wp-settings.php
+/web/wp-signup.php
+/web/wp-trackback.php
+/web/xmlrpc.php
+
+# User uploaded and system generated files.
+/web/wp-content/cache/
+/web/wp-content/uploads/
+
+# Ignore themes and plugins installed via Composer.
+/web/wp-content/plugins/*
+!/web/wp-content/plugins/README.md
+/web/wp-content/themes/*
+!/web/wp-content/themes/README.md

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -16,7 +16,7 @@ build:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-	database: "mysqldb:mysql"
+    database: "mysqldb:mysql"
 
 # The configuration of app when it is exposed to the web.
 web:
@@ -33,14 +33,14 @@ web:
             expires: 600
             scripts: true
             allow: true
-			rules:
+            rules:
                 ^/composer\.json:
                     allow: false
                 ^/license\.txt$:
                     allow: false
                 ^/readme\.html$:
                     allow: false
-		"/wp-content/cache":
+        "/wp-content/cache":
             root: "web/wp-content/cache"
             scripts: false
             allow: false
@@ -52,11 +52,11 @@ web:
 # The size of the persistent disk of the application (in MB).
 disk: 2048
 dependencies:
-	php:
-		wp-cli/wp-cli: "^1.1"
-		psy/psysh: "^0.8.4"
+    php:
+        wp-cli/wp-cli: "^1.1"
+        psy/psysh: "^0.8.4"
 # The mounts that will be performed when the package is deployed.
 mounts:
     "web/wp-content/cache": "shared:files/cache"
     "web/wp-content/uploads": "shared:files/uploads"
-	"wp": "shared:files/wp"
+    "wp": "shared:files/wp"

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -16,40 +16,47 @@ build:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-        database: "mysqldb:mysql"
+	database: "mysqldb:mysql"
 
 # The configuration of app when it is exposed to the web.
 web:
     locations:
         "/":
             # The public directory of the app, relative to its root.
-            root: "web/wp"
+            root: "web"
             # The front-controller script to send non-static requests to.
             passthru: "/index.php"
             # Wordpress has multiple roots (wp-admin) so the following is required
-            index: 
+            index:
                 - "index.php"
             # The number of seconds whitelisted (static) content should be cached.
             expires: 600
             scripts: true
             allow: true
+			rules:
+                ^/composer\.json:
+                    allow: false
+                ^/license\.txt$:
+                    allow: false
+                ^/readme\.html$:
+                    allow: false
+		"/wp-content/cache":
+            root: "web/wp-content/cache"
+            scripts: false
+            allow: false
+        "/wp-content/uploads":
+            root: "web/wp-content/uploads"
+            scripts: false
+            allow: true
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048
 dependencies:
-  php:
-    wp-cli/wp-cli: "^1.1"
-    psy/psysh: "^0.8.4"
+	php:
+		wp-cli/wp-cli: "^1.1"
+		psy/psysh: "^0.8.4"
 # The mounts that will be performed when the package is deployed.
 mounts:
-    "/web/wp-content/uploads": "shared:files/uploads"
-    "/web/wp-content/cache": "shared:files/cache"
-
-# The hooks that will be performed when the package is deployed.
-hooks:
-    build: |
-        set -e
-        cp -R web/wp/wp-content/plugins/* web/wp-content/plugins/
-        cp -R web/wp/wp-content/themes/* web/wp-content/themes/
-        # Uncomment this line when you start adding extra language packs.
-        #cp -R web/wp/wp-content/languages/* web/wp-content/languages/
+    "web/wp-content/cache": "shared:files/cache"
+    "web/wp-content/uploads": "shared:files/uploads"
+	"wp": "shared:files/wp"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can also use this repository as a reference for your own projects, and borro
 
 ## Local settings
 
-This example looks for an optional `wp-config-local.php` alongside your `wp-config.php` file that you can use to develop locally. This file is ignored in git.
+This example looks for an optional `wp-config-local.php` in the project root that you can use to develop locally. This file is ignored in git.
 
 Example `wp-config-local.php`:
 

--- a/composer.json
+++ b/composer.json
@@ -1,44 +1,45 @@
 {
-  "name": "johnpbloch/wordpress",
-  "description": "WordPress is web software you can use to create a beautiful website or blog.",
-  "keywords": [
-    "wordpress",
-    "blog",
-    "cms"
-  ],
-  "type": "package",
-  "homepage": "http://wordpress.org/",
-  "license": "GPL-2.0+",
-  "authors": [
-    {
-      "name": "WordPress Community",
-      "homepage": "http://wordpress.org/about/"
-    }
-  ],
-  "support": {
-    "issues": "http://core.trac.wordpress.org/",
-    "forum": "http://wordpress.org/support/",
-    "wiki": "http://codex.wordpress.org/",
-    "irc": "irc://irc.freenode.net/wordpress",
-    "source": "http://core.trac.wordpress.org/browser"
-  },
-  "require": {
-    "php": ">=5.3.2",
-    "johnpbloch/wordpress-core-installer": "^1.0",
-    "johnpbloch/wordpress-core": "5.0.3"
-  },
-  "extra": {
-    "wordpress-install-dir": "web/wp",
-    "installer-paths": {
-      "web/wp-content/plugins/{$name}": [
-        "type:wordpress-plugin"
+    "name": "platformsh/template-wordpress",
+    "description": "WordPress Composer-ified. A template for managing WordPress core, plugins, and themes.",
+    "keywords": [
+        "wordpress",
+        "blog",
+        "cms",
+        "template"
+    ],
+    "homepage": "https://github.com/platformsh/template-wordpress",
+    "type": "project",
+    "license": "GPL-2.0-or-later",
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://wpackagist.org"
+        }
+    ],
+    "require": {
+        "johnpbloch/wordpress": "^5.0"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "config": {
+        "discard-changes": true,
+        "sort-packages": true
+    },
+    "scripts": {
+      "update-packages": [
+          "cp -rf wp/* web/",
+          "rm -rf wp"
       ],
-      "web/wp-content/themes/{$name}": [
-        "type:wordpress-theme"
-      ],
-      "web/wp-content/mu-plugins/{$name}": [
-        "type:wordpress-muplugin"
-      ]
+      "post-install-cmd": "@update-packages",
+      "post-update-cmd": "@update-packages"
+    },
+    "extra": {
+        "wordpress-install-dir": "wp",
+        "installer-paths": {
+            "web/wp-content/plugins/{$name}": ["type:wordpress-plugin"],
+            "web/wp-content/themes/{$name}": ["type:wordpress-theme"],
+            "web/wp-content/mu-plugins/{$name}": ["type:wordpress-muplugin"],
+            "web/wp-content/{$name}": "type:wordpress-dropin"
+        }
     }
-  }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,66 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3cd961dcd7ce16fc788133c8cd80e844",
+    "content-hash": "e80a8874de3b78e4882eec950ced96d8",
     "packages": [
         {
-            "name": "johnpbloch/wordpress-core",
-            "version": "5.0.3",
+            "name": "johnpbloch/wordpress",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/johnpbloch/wordpress-core.git",
-                "reference": "76c8acab20262adc0eb70d20aace3d36c2f3a16f"
+                "url": "https://github.com/johnpbloch/wordpress.git",
+                "reference": "bdb6632aea9872b7c71322c724a8acfc0ec9ee7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/76c8acab20262adc0eb70d20aace3d36c2f3a16f",
-                "reference": "76c8acab20262adc0eb70d20aace3d36c2f3a16f",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/bdb6632aea9872b7c71322c724a8acfc0ec9ee7f",
+                "reference": "bdb6632aea9872b7c71322c724a8acfc0ec9ee7f",
+                "shasum": ""
+            },
+            "require": {
+                "johnpbloch/wordpress-core": "5.1.0",
+                "johnpbloch/wordpress-core-installer": "^1.0",
+                "php": ">=5.3.2"
+            },
+            "type": "package",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "WordPress Community",
+                    "homepage": "http://wordpress.org/about/"
+                }
+            ],
+            "description": "WordPress is web software you can use to create a beautiful website or blog.",
+            "homepage": "http://wordpress.org/",
+            "keywords": [
+                "blog",
+                "cms",
+                "wordpress"
+            ],
+            "time": "2019-02-22T18:16:29+00:00"
+        },
+        {
+            "name": "johnpbloch/wordpress-core",
+            "version": "5.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/johnpbloch/wordpress-core.git",
+                "reference": "07c57b738c9967e5643641a44e659b5851c066af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/07c57b738c9967e5643641a44e659b5851c066af",
+                "reference": "07c57b738c9967e5643641a44e659b5851c066af",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
             },
             "provide": {
-                "wordpress/core-implementation": "5.0.3"
+                "wordpress/core-implementation": "5.1.0"
             },
             "type": "wordpress-core",
             "notification-url": "https://packagist.org/downloads/",
@@ -44,7 +83,7 @@
                 "cms",
                 "wordpress"
             ],
-            "time": "2019-01-09T18:42:15+00:00"
+            "time": "2019-02-22T18:16:24+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core-installer",
@@ -98,12 +137,10 @@
     ],
     "packages-dev": [],
     "aliases": [],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "stability-flags": [],
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": {
-        "php": ">=5.3.2"
-    },
+    "platform": [],
     "platform-dev": []
 }

--- a/example.wp-config-local.php
+++ b/example.wp-config-local.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * The base configuration for WordPress
+ *
+ * The wp-config.php creation script uses this file during the
+ * installation. You don't have to use the web site, you can
+ * copy this file to "wp-config.php" and fill in the values.
+ *
+ * This file contains the following configurations:
+ *
+ * * MySQL settings
+ * * Secret keys
+ * * Database table prefix
+ * * ABSPATH
+ *
+ * @link https://codex.wordpress.org/Editing_wp-config.php
+ *
+ * @package WordPress
+ */
+
+// ** MySQL settings - You can get this info from your web host ** //
+/** The name of the database for WordPress */
+define( 'DB_NAME', 'database_name_here' );
+
+/** MySQL database username */
+define( 'DB_USER', 'username_here' );
+
+/** MySQL database password */
+define( 'DB_PASSWORD', 'password_here' );
+
+/** MySQL hostname */
+define( 'DB_HOST', 'localhost' );
+
+/** Database Charset to use in creating database tables. */
+define( 'DB_CHARSET', 'utf8' );
+
+/** The Database Collate type. Don't change this if in doubt. */
+define( 'DB_COLLATE', '' );
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+ *
+ * @since 2.6.0
+ */
+define( 'AUTH_KEY',         'put your unique phrase here' );
+define( 'SECURE_AUTH_KEY',  'put your unique phrase here' );
+define( 'LOGGED_IN_KEY',    'put your unique phrase here' );
+define( 'NONCE_KEY',        'put your unique phrase here' );
+define( 'AUTH_SALT',        'put your unique phrase here' );
+define( 'SECURE_AUTH_SALT', 'put your unique phrase here' );
+define( 'LOGGED_IN_SALT',   'put your unique phrase here' );
+define( 'NONCE_SALT',       'put your unique phrase here' );
+
+/**#@-*/
+
+/**
+ * WordPress Database Table prefix.
+ *
+ * You can have multiple installations in one database if you give each
+ * a unique prefix. Only numbers, letters, and underscores please!
+ */
+$table_prefix = 'wp_';
+
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ *
+ * For information on other constants that can be used for debugging,
+ * visit the Codex.
+ *
+ * @link https://codex.wordpress.org/Debugging_in_WordPress
+ */
+define( 'WP_DEBUG', false );

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -1,85 +1,94 @@
 <?php
 
-// Set host values
+// Set default scheme and hostname.
 $site_scheme = 'http';
 $site_host = 'localhost';
 
+// Update scheme and hostname for the requested page.
 if (isset($_SERVER['HTTP_HOST'])) {
-    $site_host = $_SERVER['HTTP_HOST'];
-    $site_scheme = !empty($_SERVER['https']) ? 'https' : 'http';
+  $site_host = $_SERVER['HTTP_HOST'];
+  $site_scheme = !empty($_SERVER['HTTPS']) ? 'https' : 'http';
 }
 
 if (getenv('PLATFORM_RELATIONSHIPS')) {
-    // This is where we get the relationships of our application dynamically
-    //from Platform.sh
+  // This is where we get the relationships of our application dynamically
+  // from Platform.sh.
 
-    // set session path to /tmp in cas we are using wp-cli to avoid notices
+    // Avoid PHP notices on CLI requests.
     if (php_sapi_name() === 'cli') {
-        session_save_path("/tmp");
+      session_save_path("/tmp");
     }
 
+    // Platform.sh services and relationships.
     $relationships = json_decode(base64_decode(getenv('PLATFORM_RELATIONSHIPS')), TRUE);
 
     // We are using the first relationship called "database" found in your
     // relationships. Note that you can call this relationship as you wish
-    // in you .platform.app.yaml file, but 'database' is a good name.
-    define('DB_NAME', $relationships['database'][0]['path']);
-    define('DB_USER', $relationships['database'][0]['username']);
-    define('DB_PASSWORD', $relationships['database'][0]['password']);
-    define('DB_HOST', $relationships['database'][0]['host']);
-    define('DB_CHARSET', 'utf8');
-    define('DB_COLLATE', '');
+    // in your `.platform.app.yaml` file, but 'database' is a good name.
+    define( 'DB_NAME', $relationships['database'][0]['path'] );
+    define( 'DB_USER', $relationships['database'][0]['username'] );
+    define( 'DB_PASSWORD', $relationships['database'][0]['password'] );
+    define( 'DB_HOST', $relationships['database'][0]['host'] );
+    define( 'DB_CHARSET', 'utf8' );
+    define( 'DB_COLLATE', '' );
 
-    // Check whether a route is defined for this application in the Platform.sh routes.
-    // Use it as the site hostname if so (it is not ideal to trust HTTP_HOST).
+    // Check whether a route is defined for this application in the Platform.sh
+    // routes. Use it as the site hostname if so (it is not ideal to trust HTTP_HOST).
     if (getenv('PLATFORM_ROUTES')) {
-        $routes = json_decode(base64_decode(getenv('PLATFORM_ROUTES')), TRUE);
-        foreach ($routes as $url => $route) {
-            if ($route['type'] === 'upstream' && $route['upstream'] === getenv('PLATFORM_APPLICATION_NAME')) {
-                // Pick the first hostname, or the first HTTPS hostname if one exists.
-                $host = parse_url($url, PHP_URL_HOST);
-                $scheme = parse_url($url, PHP_URL_SCHEME);
-                if ($host !== false && (!isset($site_host) || ($site_scheme === 'http' && $scheme === 'https'))) {
-                    $site_host = $host;
-                    $site_scheme = $scheme ?: 'http';
-                }
-            }
+      $routes = json_decode(base64_decode(getenv('PLATFORM_ROUTES')), TRUE);
+      foreach ($routes as $url => $route) {
+        if ($route['type'] === 'upstream' && $route['upstream'] === getenv('PLATFORM_APPLICATION_NAME')) {
+          // Pick the first hostname, or the first HTTPS hostname if one exists.
+          $host = parse_url($url, PHP_URL_HOST);
+          $scheme = parse_url($url, PHP_URL_SCHEME);
+          if ($host !== false && (!isset($site_host) || ($site_scheme === 'http' && $scheme === 'https'))) {
+            $site_host = $host;
+            $site_scheme = $scheme ?: 'http';
+          }
         }
+      }
     }
 
     // Debug mode should be disabled on Platform.sh. Set this constant to true
     // in a wp-config-local.php file to skip this setting on local development.
-    if (!defined('WP_DEBUG')) {
-        define('WP_DEBUG', false);
+    if (!defined( 'WP_DEBUG' )) {
+      define( 'WP_DEBUG', false );
     }
 
     // Set all of the necessary keys to unique values, based on the Platform.sh
     // entropy value.
     if (getenv('PLATFORM_PROJECT_ENTROPY')) {
-        $keys = [
-            'AUTH_KEY', 'SECURE_AUTH_KEY',
-            'LOGGED_IN_KEY', 'LOGGED_IN_SALT',
-            'NONCE_KEY', 'NONCE_SALT',
-            'AUTH_SALT', 'SECURE_AUTH_SALT',
-        ];
-        $entropy = getenv('PLATFORM_PROJECT_ENTROPY');
-        foreach ($keys as $key) {
-            if (!defined($key)) {
-                define($key, $entropy . $key);
-            }
+      $keys = [
+        'AUTH_KEY',
+        'SECURE_AUTH_KEY',
+        'LOGGED_IN_KEY',
+        'NONCE_KEY',
+        'AUTH_SALT',
+        'SECURE_AUTH_SALT',
+        'LOGGED_IN_SALT',
+        'NONCE_SALT',
+      ];
+      $entropy = getenv('PLATFORM_PROJECT_ENTROPY');
+      foreach ($keys as $key) {
+        if (!defined($key)) {
+          define( $key, $entropy . $key );
         }
-    }
-} else {
-    // You can create a wp-config-local.php file with local configuration.
-    if ( file_exists( dirname( __FILE__ ) . '/wp-config-local.php' ) ) {
-        include( dirname( __FILE__ ) . '/wp-config-local.php' );
+      }
     }
 }
+else {
+  // Local configuration file should be in project root.
+  if (file_exists(dirname(__FILE__, 2) . '/wp-config-local.php')) {
+		include(dirname(__FILE__, 2) . '/wp-config-local.php');
+	}
+}
 
-// Define wp-content directory outside of WordPress core directory
-define('WP_HOME', $site_scheme . '://' . $site_host);
-define('WP_SITEURL', WP_HOME . '/');
-
+// Do not put a slash "/" at the end.
+// https://codex.wordpress.org/Editing_wp-config.php#WP_HOME
+define( 'WP_HOME', $site_scheme . '://' . $site_host );
+// Do not put a slash "/" at the end.
+// https://codex.wordpress.org/Editing_wp-config.php#WP_SITEURL
+define( 'WP_SITEURL', WP_HOME );
 define( 'WP_CONTENT_DIR', dirname( __FILE__ ) . '/wp-content' );
 define( 'WP_CONTENT_URL', WP_HOME . '/wp-content' );
 
@@ -96,8 +105,9 @@ ini_set('pcre.backtrack_limit', 200000);
 ini_set('pcre.recursion_limit', 200000);
 
 /** Absolute path to the WordPress directory. */
-if ( !defined('ABSPATH') )
-    define('ABSPATH', dirname(__FILE__) . '/');
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __FILE__ ) . '/' );
+}
 
 /** Sets up WordPress vars and included files. */
-require_once(ABSPATH . 'wp-settings.php');
+require_once( ABSPATH . 'wp-settings.php' );

--- a/web/wp-content/languages/README.md
+++ b/web/wp-content/languages/README.md
@@ -1,2 +1,3 @@
-Place translation files here The whole directory
-will be moved inside `wp/wp-content/languages/` at the end of the build process.
+# Languages
+
+The translation files should be stored in this directory.

--- a/web/wp-content/plugins/README.md
+++ b/web/wp-content/plugins/README.md
@@ -1,5 +1,3 @@
-Place custom plugins for your project in this directory. The whole directory
-will be moved inside `wp/wp-content/plugins/` at the end of the build process.
+# Plugins
 
-Don't place contributed plugins in here, add them to the `composer.json`
-file in the root directory.
+Any plugin installed via composer will be stored in this directory.

--- a/web/wp-content/themes/README.md
+++ b/web/wp-content/themes/README.md
@@ -1,5 +1,3 @@
-Place custom themes for your project in this directory. The whole directory
-will be moved inside `wp/wp-content/themes/` at the end of the build process.
+# Themes
 
-Don't place contributed themes in here, add them to the `composer.json`
-file in the root directory.
+Any themes installed via composer will be stored in this directory.

--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,2 +1,2 @@
-path: ./web/wp/
+path: /app/web/
 color: true


### PR DESCRIPTION
* Now builds into`web` directory. Composer packages now installs directly into their appropriate parent folder, except WordPress core, for better package management.
* Updated `.gitignore` to support new build method.
* Updated `wp-cli.yml` for updated webroot.
* Normalized indentation; updated comments.
* Added example local config file.
* Added `.editorconfig` file.
